### PR TITLE
Fix Jinja2 statement used to produce a boolean value

### DIFF
--- a/molecule/server/converge.yml
+++ b/molecule/server/converge.yml
@@ -10,4 +10,9 @@
         name: ansible-role-samba
       vars:
         samba_create_guest_user: true
+        samba_guest_user: smbuser
+        samba_guest_user_uid: 2048
+        samba_guest_user_groups:
+          # This is just an already available group to use for testing.
+          - cdrom
         samba_server: true

--- a/molecule/server/tests/test_server.py
+++ b/molecule/server/tests/test_server.py
@@ -42,8 +42,10 @@ def test_service_enabled(host):
 
 def test_guest_user(host):
     """Test that Samba guest user was created."""
-    user = host.user("smbguest")
+    user = host.user("smbuser")
     assert user.exists
+    assert user.uid == 2048
     assert user.home == "/dev/null"
     assert user.shell == "/sbin/nologin"
     assert user.gecos == "Samba guest account"
+    assert "cdrom" in user.groups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
           ansible.builtin.user:
             # Only set to true if the variable is defined and
             # non-empty.
-            append: "{{ samba_guest_user_groups is defined and samba_guest_user_groups }}"
+            append: "{{ samba_guest_user_groups is defined and samba_guest_user_groups | bool }}"
             comment: Samba guest account
             create_home: false
             groups: "{{ samba_guest_user_groups | default(omit) }}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates testing to check all options available for creating the Samba guest user as well as fixing the Jinja2 statement used to generate the value for the [`append` argument of the `ansible.builtin.user` module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-append).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This role currently fails when the `samba_guest_user_groups` variable is provided as can be seen in [this cisagov/samba-packer run](https://github.com/cisagov/samba-packer/actions/runs/8533785831/job/23377103482?pr=45#step:16:396) and [this run in this repository](https://github.com/cisagov/ansible-role-samba/actions/runs/8534413170/job/23378784032#step:9:387). This is because the Jinja2 statement used to generate a value for the `append` argument does not correctly produce a boolean value
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
